### PR TITLE
Apply global invert filter except icons

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -10,6 +10,7 @@ body {
     color: #fff;
     height: 100vh;
     overflow: hidden;
+    filter: invert(1) hue-rotate(180deg);
 }
 
 .container {
@@ -266,3 +267,12 @@ body {
 .rainy-icon {
     fill: #5dabf4;
 }
+
+/* Keep icons in normal colors when the page is inverted */
+.calendar-entry-icon,
+.weather-icon svg,
+.day-icon svg,
+.weather-icon img {
+    filter: invert(1) hue-rotate(180deg);
+}
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -9,6 +9,7 @@ body {
     background-color: #f5f5f5;
     color: #333;
     line-height: 1.6;
+    filter: invert(1) hue-rotate(180deg);
 }
 
 /* Dashboard layout */
@@ -188,3 +189,10 @@ body {
         margin-top: 10px;
     }
 }
+
+/* Keep icons in normal colors when the page is inverted */
+.calendar-entry-icon,
+.weather-icon img {
+    filter: invert(1) hue-rotate(180deg);
+}
+


### PR DESCRIPTION
## Summary
- invert the page colors for a dark look
- keep icon colors normal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841739e80588332ac3f9a23c754ce35