### PR TITLE
Apply dark theme

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,8 +6,8 @@
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    background-color: #f5f5f5;
-    color: #333;
+    background-color: #000;
+    color: #fff;
     line-height: 1.6;
 }
 
@@ -20,7 +20,7 @@ body {
 
 /* Header section */
 .header {
-    background-color: #fff;
+    background-color: #000;
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -34,12 +34,12 @@ body {
 #current-time {
     font-size: 3em;
     font-weight: 300;
-    color: #333;
+    color: #fff;
 }
 
 #current-date {
     font-size: 1.2em;
-    color: #666;
+    color: #fff;
     margin-top: 5px;
 }
 
@@ -52,14 +52,14 @@ body {
 
 /* Calendar section */
 .calendar-section {
-    background-color: #fff;
+    background-color: #000;
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .calendar-section h2 {
-    color: #333;
+    color: #fff;
     margin-bottom: 15px;
     font-size: 1.5em;
 }
@@ -92,32 +92,32 @@ body {
 }
 
 .calendar-entry-time {
-    color: #666;
+    color: #fff;
     font-size: 0.9em;
 }
 
 .calendar-entry-location {
-    color: #666;
+    color: #fff;
     font-size: 0.9em;
     margin-top: 3px;
 }
 
 .calendar-entry-calendar {
-    color: #999;
+    color: #fff;
     font-size: 0.8em;
     margin-top: 3px;
 }
 
 /* Weather section */
 .weather-section {
-    background-color: #fff;
+    background-color: #000;
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .weather-section h2 {
-    color: #333;
+    color: #fff;
     margin-bottom: 15px;
     font-size: 1.5em;
 }
@@ -156,7 +156,7 @@ body {
 
 .weather-desc {
     flex: 1;
-    color: #666;
+    color: #fff;
     font-size: 0.9em;
     margin-left: 15px;
 }
@@ -165,7 +165,7 @@ body {
 .error, .no-events {
     text-align: center;
     padding: 20px;
-    color: #666;
+    color: #fff;
 }
 
 /* Responsive design */


### PR DESCRIPTION
## Summary
- switch to dark background and white text
- update calendar and weather sections accordingly

## Testing
- `python -m py_compile app.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684178aa6854833293d5d885772860ad